### PR TITLE
ElevatorHeight

### DIFF
--- a/src/main/java/frc/robot/subsystems/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/elevator/Elevator.java
@@ -22,6 +22,7 @@ public class Elevator extends SubsystemBase {
   @Override
   public void periodic() {
     // This method will be called once per scheduler run
+    io.updateValues();
     Logger.recordOutput("Elevator/3dSetpoint", new Pose3d(0, io.getHeightMeters(), 0, new Rotation3d()));
     io.updateLimitSwitch();
   }

--- a/src/main/java/frc/robot/subsystems/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/elevator/Elevator.java
@@ -4,6 +4,10 @@
 
 package frc.robot.subsystems.elevator;
 
+import org.littletonrobotics.junction.Logger;
+
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class Elevator extends SubsystemBase {
@@ -18,7 +22,7 @@ public class Elevator extends SubsystemBase {
   @Override
   public void periodic() {
     // This method will be called once per scheduler run
-    io.updateValues();
+    Logger.recordOutput("Elevator/3dSetpoint", new Pose3d(0, io.getHeightMeters(), 0, new Rotation3d()));
     io.updateLimitSwitch();
   }
 

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorConstants.java
@@ -19,6 +19,8 @@ public class ElevatorConstants {
     public static final double defaultPosition = 0.5;
     public static final double algaeRemovalHeightLow = 0;
     public static final double algaeRemovalHeightHigh = 42; // TODO: change this to the correct number
+    public static final double elevatorRange = 0.622;
+    public static final double heightToEncoderRatio = elevatorRange / coralLimit;
     // these are the constants for the elevator pid
     public static final double kElevatorP = .3;
     public static final double kElevatorI = 0;

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIO.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIO.java
@@ -47,4 +47,12 @@ public interface ElevatorIO {
     public default boolean getLimitReset() {
         return true;
     }
+
+    public default double getHeightMeters() {
+        return 0;
+    }
+
+    public default void setHeightMeters(double height) {
+
+    }
 }

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIOSparkMax.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIOSparkMax.java
@@ -181,4 +181,15 @@ public class ElevatorIOSparkMax implements ElevatorIO {
   public boolean getLimitReset() {
     return limitReset;
   }
+
+  @Override
+  public double getHeightMeters() {
+    return getHeight() * ElevatorConstants.heightToEncoderRatio;
+  }
+
+  @Override
+  public void setHeightMeters(double height) {
+    elevateTo(height / ElevatorConstants.heightToEncoderRatio);
+  }
+
 }


### PR DESCRIPTION
Logs the elevator height in meters in a Pose3d. This should allow us to log the position of the elevator in the future in AdvantageScope, and get some pretty cool log representations.(not a priority at all, but should be safe to merge in, and then from there we can view those log files post season and pull down the data, to get some pretty cool visuals.)
![image](https://github.com/user-attachments/assets/e258689e-50cf-4250-8c8c-412a0af7cf7a)
+
![image](https://github.com/user-attachments/assets/89c1a191-3b06-498b-9b0c-56f4739ae791)
\=
![image](https://github.com/user-attachments/assets/4fce4d4e-b9cd-4d9c-b1d5-829198c75fe0)

Whoever approves this first will get a sweet high-five!